### PR TITLE
Address possible permission issues in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,18 @@ We encourage you to check the package `com.polidea.rxandroidble.helpers` which c
 #### Observing BluetoothAdapter state
 If you would like to observe `BluetoothAdapter` state changes you can use `RxBleAdapterStateObservable`.
 
+### Permissions
+
+RxAndroidBle already provides all the necessary bluetooth permissions for you. Recently, Google has started checking these
+when releasing to the Play Store. If you have ACCESS_COARSE_LOCATION set manually you may run into an issue where your permission do not merge with RxAndroidBle's, resulting in a failure to upload to the Play Store This permission is only required on SDK 23+. If you need this permission 
+on a lower version of Android use:
+
+```<uses-permission
+  android:name="android.permission.ACCESS_COARSE_LOCATION"
+  android:maxSdkVersion="22"/>
+  ```
+
+
 ## More examples
 
 Complete usage examples are located in `/sample` [GitHub repo](https://github.com/Polidea/RxAndroidBle/tree/master/sample/src/main/java/com/polidea/rxandroidble/sample).


### PR DESCRIPTION
Recently it seems like google has started checking for duplicate permissions in the play store. resulting in some issues when uploading:

https://stackoverflow.com/questions/44299197/google-play-apk-upload-error-duplicate-declarations-of-permission

Add some documentation to state that RxAndroidBle handles permissions for you and how to handle it if you need ACCESS_COARSE_LOCATION on versions < 23